### PR TITLE
config: fix indentation in app

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -9,9 +9,9 @@ overview: |-
 
 # Markdown description of this entry
 readme: |
-This `stack-rook` repository is the implementation of a Crossplane infrastructure
-[stack](https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md) for
-[Rook](https://rook.io/).
+ This `stack-rook` repository is the implementation of a Crossplane infrastructure
+ [stack](https://github.com/crossplaneio/crossplane/blob/master/design/design-doc-stacks.md) for
+ [Rook](https://rook.io/).
  The stack that is built from the source code in this repository can be installed into a Crossplane control plane and adds the following new functionality:
 
  * Custom Resource Definitions (CRDs) that model Rook infrastructure and services (e.g. [Yugabyte](https://github.com/yugabyte/yugabyte-db), [CockroachDB](https://github.com/cockroachdb/cockroach), etc.)


### PR DESCRIPTION
Minor fix in `app.yaml` that was preventing successful stack install.