### PR TITLE
config: give stack-rook permissions on kubernetes crossplane crd group

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -52,6 +52,7 @@ dependsOn:
 - crd: '*.cache.crossplane.io/v1alpha1'
 - crd: '*.compute.crossplane.io/v1alpha1'
 - crd: '*.database.crossplane.io/v1alpha1'
+- crd: '*.kubernetes.crossplane.io/v1alpha1'
 - crd: '*.core.crossplane.io/v1alpha1'
 - crd: '*.storage.crossplane.io/v1alpha1'
 - crd: '*.workload.crossplane.io/v1alpha1'


### PR DESCRIPTION
Other stacks do not currently have this permission enabled because they don't have any controllers that utilize the Kubernetes `Provider`.