### PR TITLE
build: bump stack version to v0.1.0

### DIFF
--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -21,7 +21,7 @@ readme: |
 # Version of project (optional)
 # If omitted the version will be filled with the docker tag
 # If set it must match the docker tag
-version: 0.0.1
+version: v0.1.0
 
 # Maintainer names and emails.
 maintainers:

--- a/config/stack/manifests/install.yaml
+++ b/config/stack/manifests/install.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: "stack-rook-controller"
-        image: "crossplane/stack-rook:master"
+        image: "crossplane/stack-rook:v0.1.0"
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
This PR bumps the stack version to v0.1.0 in its internal metadata.

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-aws/blob/master/config/stack/manifests/app.yaml

[skip ci]