### PR TITLE
Bump stack-rook version refs to v0.3.0

### DIFF
--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -18,7 +18,7 @@ echo_sub_step(){
 }
 
 echo_step_completed(){
-    printf "${GRN} [✔]${NOC}" 
+    printf "${GRN} [✔]${NOC}"
 }
 
 echo_success(){
@@ -59,7 +59,7 @@ wait_for_pods_in_namespace(){
     local timeout=$1
     shift
     namespace=$1
-    shift 
+    shift
     arr=("$@")
     local counter=0
     for i in "${arr[@]}";
@@ -85,7 +85,7 @@ check_deployments(){
             exit -1
         else
             echo_step_completed
-        fi 
+        fi
 
         echo_info "check if is ready"
         IFS='/' read -ra ready_status_parts <<< "$(echo "$dep_stat" | awk ' FNR > 1 {print $2}')"
@@ -102,7 +102,7 @@ check_deployments(){
 check_pods(){
     pods=$("${KUBECTL}" -n "$1" get pods)
     echo "$pods"
-    while read -r pod_stat; do 
+    while read -r pod_stat; do
         name=$(echo "$pod_stat" | awk '{print $1}')
         echo_sub_step "inspecting pod '${name}'"
 
@@ -112,7 +112,7 @@ check_pods(){
             echo_info "is completed, foregoing further checks"
             echo_step_completed
             continue
-        fi 
+        fi
 
         echo_info "check if is ready"
         IFS='/' read -ra ready_status_parts <<< "$(echo "$pod_stat" | awk '{print $2}')"
@@ -129,7 +129,7 @@ check_pods(){
             exit -1
         else
             echo_step_completed
-        fi 
+        fi
 
         echo_info "check if has restarts"
         if (( $(echo "$pod_stat" | awk '{print $4}') > 0 )); then
@@ -167,7 +167,7 @@ BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${HOSTARCH}"
 
 version_tag="$(cat ${projectdir}/_output/version)"
 # tag as master so that config/stack/install.yaml can be used
-STACK_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:master"
+STACK_IMAGE="${DOCKER_REGISTRY}/${PROJECT_NAME}:v0.3.0"
 K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-INTTESTS}"
 
 CROSSPLANE_NAMESPACE="crossplane-system"

--- a/config/stack/manifests/app.yaml
+++ b/config/stack/manifests/app.yaml
@@ -21,7 +21,7 @@ readme: |
 # Version of project (optional)
 # If omitted the version will be filled with the docker tag
 # If set it must match the docker tag
-version: 0.0.1
+version: v0.3.0
 
 # Maintainer names and emails.
 maintainers:

--- a/config/stack/manifests/install.yaml
+++ b/config/stack/manifests/install.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: "stack-rook-controller"
-        image: "crossplane/stack-rook:master"
+        image: "crossplane/stack-rook:v0.3.0"
         env:
         - name: POD_NAME
           valueFrom:

--- a/config/stack/manifests/resources/cockroachclusterclass.resource.yaml
+++ b/config/stack/manifests/resources/cockroachclusterclass.resource.yaml
@@ -6,5 +6,4 @@ overviewShort: "A CockroachClusterClass is a resource class. It defines the desi
 overview: |
   A CockroachClusterClass is a resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource.
 readme: |
-  Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplaneio/stack-rook/storage-rook-crossplane-io-v1alpha1.html#CockroachClusterClass).
-
+  Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/0.6/api/crossplaneio/stack-rook/storage-rook-crossplane-io-v1alpha1.html#CockroachClusterClass).

--- a/config/stack/manifests/resources/yugabyteclusterclass.resource.yaml
+++ b/config/stack/manifests/resources/yugabyteclusterclass.resource.yaml
@@ -6,4 +6,4 @@ overviewShort: "A YugabyteClusterClass is a resource class. It defines the desir
 overview: |
   A YugabyteClusterClass is a resource class. It defines the desired spec of resource claims that use it to dynamically provision a managed resource.
 readme: |
-  Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/master/api/crossplaneio/stack-rook/storage-rook-crossplane-io-v1alpha1.html#YugabyteClusterClass).
+  Full documentation can be found in the Crossplane [API Reference docs](https://crossplane.io/docs/0.6/api/crossplaneio/stack-rook/storage-rook-crossplane-io-v1alpha1.html#YugabyteClusterClass).


### PR DESCRIPTION
### Description of your changes

This PR bumps the internal stack references to the soon to be released version of v0.3.0, as well as updating the stack resource readmes to reference the soon to be released crossplane.io docs version 0.6.

### Checklist
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Ensured this PR contains a neat, self documenting set of commits.
- [x] Updated any relevant [documentation], [examples], or [release notes].
- [x] Updated the dependencies in [`app.yaml`] to include any new role permissions.

[documentation]: https://github.com/crossplaneio/crossplane/tree/master/docs
[examples]: https://github.com/crossplaneio/crossplane/tree/master/cluster/examples
[release notes]: https://github.com/crossplaneio/crossplane/tree/master/PendingReleaseNotes.md
[`app.yaml`]: https://github.com/crossplaneio/stack-gcp/blob/master/config/stack/manifests/app.yaml
